### PR TITLE
chore: deploy after pr merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy to Prod
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup SSH Key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          echo "${{ secrets.SSH_CONFIG }}" > ~/.ssh/config
+          chmod 600 ~/.ssh/{id_rsa,config}
+        shell: bash
+
+      - name: Deploy via SSH
+        run: |
+          ssh prod "
+            cd /opt/www/api.infini.sh &&
+            git pull origin gh-pages &&
+            git log -n 1 --pretty=format:"%h - %ad, %s" --date=short
+          "
+        shell: bash


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate deployments to the production environment. The workflow is triggered by a push to the `main` branch or manually via the GitHub interface.

Key changes include:

* Added a new workflow configuration file `.github/workflows/deploy.yml` to define the deployment process.
* The workflow sets up an SSH key using secrets stored in GitHub and deploys the latest changes to the production server by pulling from the `gh-pages` branch.